### PR TITLE
[#578] Fix error when current value key includes "na"

### DIFF
--- a/frontend/src/akvo-react-form/components/DataUnavailableField.jsx
+++ b/frontend/src/akvo-react-form/components/DataUnavailableField.jsx
@@ -24,9 +24,9 @@ const DataUnavailableField = ({
   }
 
   return (
-    <Form.Item key={`na_${keyform}`} name={`na_${id}`} noStyle>
+    <Form.Item key={`dataNA_${keyform}`} name={`dataNA_${id}`} noStyle>
       <Checkbox
-        id={`na_${id}`}
+        id={`dataNA_${id}`}
         checked={naChecked}
         onChange={(e) => {
           setNaChecked(e.target.checked);

--- a/frontend/src/pages/data-cleaning/DataCleaningWebform.jsx
+++ b/frontend/src/pages/data-cleaning/DataCleaningWebform.jsx
@@ -401,7 +401,7 @@ const DataCleaningWebform = ({
   const onChange = ({ current, values /*progress*/ }) => {
     // handle data unavailable checkbox - comment
     const allKeyWithNA = Object.keys(values)
-      .filter((key) => key.includes("na"))
+      .filter((key) => key.includes("dataNA_"))
       .map((key) => {
         const elCheckUnavailable = document.getElementById(key);
         const isChecked = elCheckUnavailable?.checked;
@@ -413,7 +413,7 @@ const DataCleaningWebform = ({
       })
       .reduce((acc, curr) => ({ ...acc, ...curr }), {});
     const dataUnavailable = Object.keys(current)
-      .filter((key) => key.includes("na"))
+      .filter((key) => key.includes("dataNA_"))
       .map((key) => {
         const elCheckUnavailable = document.getElementById(key);
         const isChecked = elCheckUnavailable?.checked;
@@ -476,7 +476,7 @@ const DataCleaningWebform = ({
 
     // handle form values
     const filteredValues = Object.keys(values)
-      .filter((key) => !key.includes("na"))
+      .filter((key) => !key.includes("dataNA_"))
       .reduce((acc, curr) => ({ ...acc, [curr]: values[curr] }), {});
 
     const transformValues = Object.keys(filteredValues)

--- a/frontend/src/pages/survey/WebformPage.jsx
+++ b/frontend/src/pages/survey/WebformPage.jsx
@@ -815,7 +815,7 @@ const WebformPage = ({
   const onChange = ({ current, values }) => {
     // handle data unavailable checkbox - comment
     const allKeyWithNA = Object.keys(values)
-      .filter((key) => key.includes("na"))
+      .filter((key) => key.includes("dataNA_"))
       .map((key) => {
         const elCheckUnavailable = document.getElementById(key);
         const isChecked = elCheckUnavailable?.checked;
@@ -827,7 +827,7 @@ const WebformPage = ({
       })
       .reduce((acc, curr) => ({ ...acc, ...curr }), {});
     const dataUnavailable = Object.keys(current)
-      .filter((key) => key.includes("na"))
+      .filter((key) => key.includes("dataNA_"))
       .map((key) => {
         const elCheckUnavailable = document.getElementById(key);
         const isChecked = elCheckUnavailable?.checked;
@@ -874,7 +874,7 @@ const WebformPage = ({
 
     // handle form values
     const filteredValues = Object.keys(values)
-      .filter((key) => !key.includes("na"))
+      .filter((key) => !key.includes("dataNA_"))
       .reduce((acc, curr) => ({ ...acc, [curr]: values[curr] }), {});
     const transformedAnswerValues = transformValues(filteredValues, {
       ...allKeyWithNA,


### PR DESCRIPTION
- #578 
---
### Problem:
- We currently check for the "data unavailable" field using `key.includes("na")`.
- Previously, we only used numbers as the repeat index, so this worked fine.
- Now, we've decided to use strings as the repeat index, which introduces cases like `qid-Ghana`, causing unintended matches with `key.includes("na")`.

### Fix:
- Update the "data unavailable" field name to `dataNA_id` instead of using `na_id`.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209303921698338