### PR TITLE
[#609] Show display name for project survey in downloads page

### DIFF
--- a/frontend/src/pages/download/Download.jsx
+++ b/frontend/src/pages/download/Download.jsx
@@ -155,6 +155,16 @@ const Download = () => {
       dataIndex: "form",
       key: "form",
       width: "10%",
+      render: (_, record) => {
+        if (
+          record.form_type === "project" &&
+          record.name &&
+          record.name !== ""
+        ) {
+          return `${record.form} - ${record.name}`;
+        }
+        return record.form;
+      },
     },
     {
       title: text.formTypeText,


### PR DESCRIPTION
- #609 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209493573953917